### PR TITLE
Rename Log() function to Logf()

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Easy logging in Go
 var log = logger.New("ns=project")
 
 // ns=project foo=bar num=5 pct=68.9 arg="test"
-log.Log("foo=bar num=%d pct=%0.1f arg=%q", 5, 68.99, "test")
+log.Logf("foo=bar num=%d pct=%0.1f arg=%q", 5, 68.99, "test")
 
 // ns=project sub=worker state=success foo=bar
 log.Namespace("sub=worker").Success("foo=bar")
@@ -24,7 +24,7 @@ log.Error(fmt.Errorf("invalid token"))
 
 // ns=project foo=bar elapsed=2.398
 l := log.Start()
-l.Log("foo=bar")
+l.Logf("foo=bar")
 ```
 
 ## License

--- a/logger.go
+++ b/logger.go
@@ -42,7 +42,7 @@ func (l *Logger) Step(step string) *Logger {
 func (l *Logger) Error(err error) {
 	id := rand.Int31()
 
-	l.Log("state=error id=%d message=%q", id, err)
+	l.Logf("state=error id=%d message=%q", id, err)
 
 	stack := make([]byte, 102400)
 	runtime.Stack(stack, false)
@@ -51,12 +51,12 @@ func (l *Logger) Error(err error) {
 	line := 1
 
 	for scanner.Scan() {
-		l.Log("state=error id=%d line=%d trace=%q", id, line, scanner.Text())
+		l.Logf("state=error id=%d line=%d trace=%q", id, line, scanner.Text())
 		line += 1
 	}
 }
 
-func (l *Logger) Log(format string, args ...interface{}) {
+func (l *Logger) Logf(format string, args ...interface{}) {
 	if l.started.IsZero() {
 		l.writer.Write([]byte(fmt.Sprintf("%s %s\n", l.namespace, fmt.Sprintf(format, args...))))
 	} else {
@@ -98,5 +98,5 @@ func (l *Logger) Start() *Logger {
 }
 
 func (l *Logger) Success(format string, args ...interface{}) {
-	l.Log("state=success %s", fmt.Sprintf(format, args...))
+	l.Logf("state=success %s", fmt.Sprintf(format, args...))
 }

--- a/logger_test.go
+++ b/logger_test.go
@@ -24,13 +24,13 @@ func TestNew(t *testing.T) {
 
 func TestAt(t *testing.T) {
 	log := NewLogger()
-	log.At("target").Log("foo=bar")
+	log.At("target").Logf("foo=bar")
 	assertLine(t, buffer.String(), `ns=test at=target foo=bar`)
 }
 
 func TestAtOverrides(t *testing.T) {
 	log := NewLogger()
-	log.At("target1").At("target2").Log("foo=bar")
+	log.At("target1").At("target2").Logf("foo=bar")
 	assertLine(t, buffer.String(), `ns=test at=target2 foo=bar`)
 }
 
@@ -49,25 +49,25 @@ func TestError(t *testing.T) {
 
 func TestLog(t *testing.T) {
 	log := NewLogger()
-	log.Log("string=%q int=%d float=%0.2f", "foo", 42, 3.14159)
+	log.Logf("string=%q int=%d float=%0.2f", "foo", 42, 3.14159)
 	assertLine(t, buffer.String(), `ns=test string="foo" int=42 float=3.14`)
 }
 
 func TestNamespace(t *testing.T) {
 	log := NewLogger()
-	log.Namespace("foo=bar").Namespace("baz=qux").Log("fred=barney")
+	log.Namespace("foo=bar").Namespace("baz=qux").Logf("fred=barney")
 	assertLine(t, buffer.String(), `ns=test foo=bar baz=qux fred=barney`)
 }
 
 func TestReplace(t *testing.T) {
 	log := NewLogger()
-	log.Namespace("baz=qux1").Replace("baz", "qux2").Log("foo=bar")
+	log.Namespace("baz=qux1").Replace("baz", "qux2").Logf("foo=bar")
 	assertLine(t, buffer.String(), `ns=test baz=qux2 foo=bar`)
 }
 
 func TestReplaceExisting(t *testing.T) {
 	log := NewLogger()
-	log.Namespace("foo=bar").Namespace("baz=qux").Replace("baz", "zux").Log("thud=grunt")
+	log.Namespace("foo=bar").Namespace("baz=qux").Replace("baz", "zux").Logf("thud=grunt")
 	assertLine(t, buffer.String(), `ns=test foo=bar baz=zux thud=grunt`)
 }
 
@@ -79,13 +79,13 @@ func TestStart(t *testing.T) {
 
 func TestStep(t *testing.T) {
 	log := NewLogger()
-	log.Step("target").Log("foo=bar")
+	log.Step("target").Logf("foo=bar")
 	assertLine(t, buffer.String(), `ns=test step=target foo=bar`)
 }
 
 func TestStepOverrides(t *testing.T) {
 	log := NewLogger()
-	log.Step("target1").Step("target2").Log("foo=bar")
+	log.Step("target1").Step("target2").Logf("foo=bar")
 	assertLine(t, buffer.String(), `ns=test step=target2 foo=bar`)
 }
 


### PR DESCRIPTION
The current code doesn't pass `go vet`:

```
logger.go:45: possible formatting directive in Log call
logger.go:54: possible formatting directive in Log call
logger.go:101: possible formatting directive in Log call
logger_test.go:52: possible formatting directive in Log call
exit status 1
```

It fails because `go vet` assumes it found the [Log function](http://golang.org/pkg/testing/#B.Log) from Go's `testing` library, which doesn't take format specifiers. Any codebase using `logger` will also see similar errors from `go vet`.

There's a convention in Go to append "f" to the function name if it takes format specifiers. For example, see the corresponding [Logf function](http://golang.org/pkg/testing/#B.Logf) in the `testing` library. So to be consistent and satisfy `go vet`, I propose renaming `Log` to `Logf`.

Unfortunately, this breaks all users of `logger`...
